### PR TITLE
[issues#182] Update openapi.yaml spec with correct search response schema

### DIFF
--- a/cmd/server/search_handlers_test.go
+++ b/cmd/server/search_handlers_test.go
@@ -39,11 +39,16 @@ func TestSearch__ACHName(t *testing.T) {
 	//fmt.Printf("%s", w.Body.String())
 
 	var wrapper struct {
-		ACHParticipants []*fed.ACHParticipant `json:"achParticipants"`
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
+		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.WIREParticipants != nil {
+		t.Errorf("Wire participants should be nil")
 	}
 
 	for _, p := range wrapper.ACHParticipants {
@@ -72,11 +77,16 @@ func TestSearch__ACHRoutingNumber(t *testing.T) {
 	}
 
 	var wrapper struct {
-		ACHParticipants []*fed.ACHParticipant `json:"achParticipants"`
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
+		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.WIREParticipants != nil {
+		t.Errorf("Wire participants should be nil")
 	}
 
 	for _, p := range wrapper.ACHParticipants {
@@ -106,11 +116,16 @@ func TestSearch__ACHCity(t *testing.T) {
 	}
 
 	var wrapper struct {
-		ACHParticipants []*fed.ACHParticipant `json:"achParticipants"`
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
+		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.WIREParticipants != nil {
+		t.Errorf("Wire participants should be nil")
 	}
 
 	for _, p := range wrapper.ACHParticipants {
@@ -139,11 +154,16 @@ func TestSearch__ACHState(t *testing.T) {
 	}
 
 	var wrapper struct {
-		ACHParticipants []*fed.ACHParticipant `json:"achParticipants"`
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
+		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.WIREParticipants != nil {
+		t.Errorf("Wire participants should be nil")
 	}
 
 	for _, p := range wrapper.ACHParticipants {
@@ -172,7 +192,12 @@ func TestSearch__ACHPostalCode(t *testing.T) {
 	}
 
 	var wrapper struct {
-		ACHParticipants []*fed.ACHParticipant `json:"achParticipants"`
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
+		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
+	}
+
+	if wrapper.WIREParticipants != nil {
+		t.Errorf("Wire participants should be nil")
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
@@ -205,11 +230,16 @@ func TestSearch__ACH(t *testing.T) {
 	}
 
 	var wrapper struct {
-		ACHParticipants []*fed.ACHParticipant `json:"achParticipants"`
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
+		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.WIREParticipants != nil {
+		t.Errorf("Wire participants should be nil")
 	}
 
 	for _, p := range wrapper.ACHParticipants {
@@ -273,11 +303,16 @@ func TestSearch__WIREName(t *testing.T) {
 	}
 
 	var wrapper struct {
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
 		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.ACHParticipants != nil {
+		t.Errorf("ACH participants should be nil")
 	}
 
 	for _, p := range wrapper.WIREParticipants {
@@ -306,11 +341,16 @@ func TestSearch__WIRERoutingNumber(t *testing.T) {
 	}
 
 	var wrapper struct {
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
 		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.ACHParticipants != nil {
+		t.Errorf("ACH participants should be nil")
 	}
 
 	for _, p := range wrapper.WIREParticipants {
@@ -339,11 +379,16 @@ func TestSearch__WIREState(t *testing.T) {
 	}
 
 	var wrapper struct {
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
 		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.ACHParticipants != nil {
+		t.Errorf("ACH participants should be nil")
 	}
 
 	for _, p := range wrapper.WIREParticipants {
@@ -372,11 +417,16 @@ func TestSearch__WIRECity(t *testing.T) {
 	}
 
 	var wrapper struct {
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
 		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.ACHParticipants != nil {
+		t.Errorf("ACH participants should be nil")
 	}
 
 	for _, p := range wrapper.WIREParticipants {
@@ -405,11 +455,16 @@ func TestSearch__WIRE(t *testing.T) {
 	}
 
 	var wrapper struct {
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
 		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.ACHParticipants != nil {
+		t.Errorf("ACH participants should be nil")
 	}
 
 	for _, p := range wrapper.WIREParticipants {
@@ -525,11 +580,16 @@ func TestSearch__WIREStateSoftLimit(t *testing.T) {
 	}
 
 	var wrapper struct {
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
 		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.ACHParticipants != nil {
+		t.Errorf("ACH participants should be nil")
 	}
 
 	if len(wrapper.WIREParticipants) != 100 {
@@ -556,11 +616,16 @@ func TestSearch__WIREStateLimit(t *testing.T) {
 	}
 
 	var wrapper struct {
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
 		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.ACHParticipants != nil {
+		t.Errorf("ACH participants should be nil")
 	}
 
 	if len(wrapper.WIREParticipants) != 110 {
@@ -587,11 +652,16 @@ func TestSearch__WIREStateHardLimit(t *testing.T) {
 	}
 
 	var wrapper struct {
+		ACHParticipants  []*fed.ACHParticipant  `json:"achParticipants"`
 		WIREParticipants []*fed.WIREParticipant `json:"wireParticipants"`
 	}
 
 	if err := json.NewDecoder(w.Body).Decode(&wrapper); err != nil {
 		t.Fatal(err)
+	}
+
+	if wrapper.ACHParticipants != nil {
+		t.Errorf("ACH participants should be nil")
 	}
 
 	if len(wrapper.WIREParticipants) != 500 {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -88,7 +88,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ACHDictionary'
+                $ref: '#/components/schemas/SearchResponse'
         '400':
           description: Invalid, check error(s).
           content:
@@ -151,7 +151,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WIREDictionary'
+                $ref: '#/components/schemas/SearchResponse'
         '400':
           description: Invalid, check error(s).
           content:
@@ -163,13 +163,17 @@ paths:
 
 components:
   schemas:
-    ACHDictionary:
-      description: Search results containing ACHDictionary of Participants
+    SearchResponse:
+      description: Search results containing FedSearchResponse of ACH/Wire Participants
       properties:
         ACHParticipants:
           type: array
           items:
             $ref: '#/components/schemas/ACHParticipant'
+        WIREParticipants:
+          type: array
+          items:
+            $ref: '#/components/schemas/WIREParticipant'
     ACHParticipant:
       description: ACHParticipant holds a FedACH dir routing record as defined by Fed ACH Format.  https://www.frbservices.org/EPaymentsDirectory/achFormat.html
       properties:
@@ -294,13 +298,6 @@ components:
           maxLength: 4
           description: Postal Code Extension
           example: '0000'
-    WIREDictionary:
-      description: Search results containing WIREDictionary of Participants
-      properties:
-        WIREParticipants:
-          type: array
-          items:
-            $ref: '#/components/schemas/WIREParticipant'
     WIREParticipant:
       description: WIREParticipant holds a FedWIRE dir routing record as defined by Fed WIRE Format.  https://frbservices.org/EPaymentsDirectory/fedwireFormat.html
       properties:


### PR DESCRIPTION
#### Changes
- Update openapi.yaml spech with correct search response schema for both ACH and Wire search
- Updated search_handlers_test.go tests